### PR TITLE
re-instantiate stringified dates

### DIFF
--- a/test/persistency.test.ts
+++ b/test/persistency.test.ts
@@ -5,12 +5,13 @@ afterEach(() => {
 })
 
 test('hydrates cookies from localStorage', () => {
+  const expires = new Date(Date.now() + 1000);
   localStorage.setItem(
     PERSISTENCY_KEY,
     JSON.stringify([
       [
         'https://mswjs.io',
-        [['cookieName', { name: 'cookieName', value: 'abc-123' }]],
+        [['cookieName', { name: 'cookieName', expires, value: 'abc-123' }]],
       ],
     ])
   )
@@ -24,6 +25,7 @@ test('hydrates cookies from localStorage', () => {
   expect(cookie?.size).toBe(1)
   expect(cookie?.get('cookieName')).toEqual({
     name: 'cookieName',
+    expires,
     value: 'abc-123',
   })
 })


### PR DESCRIPTION
This PR is intended to fix the parsing of persisted cookies. Up to now stringified dates are not handled correctly (or not handled at all).