### PR TITLE
fix: overwrite existing cookies

### DIFF
--- a/src/CookieStore.ts
+++ b/src/CookieStore.ts
@@ -51,7 +51,7 @@ class CookieStore {
             : new Date(now + maxAge * 1000),
         maxAge,
       })
-    ).filter(({ expires }) => expires === undefined || expires.getTime() > now)
+    )
 
     const prevCookies =
       this.store.get(requestUrl.origin) || new Map<string, Cookie>()

--- a/test/expiry.test.ts
+++ b/test/expiry.test.ts
@@ -14,8 +14,7 @@ test('does not add expired cookies', () => {
 
   // Assert cookie entry has not been added.
   const allCookies = store.getAll()
-  const allCookiesList = Array.from(allCookies.entries())
-  expect(allCookiesList).toHaveLength(0)
+  expect(allCookies.size).toBe(0)
 
   // Assert the cookie can't be retrieved given a matching request.
   const reqCookies = store.get(req)
@@ -32,8 +31,7 @@ test('does not add cookies with a max age of zero', () => {
 
   // Assert cookie entry has not been added.
   const allCookies = store.getAll()
-  const allCookiesList = Array.from(allCookies.entries())
-  expect(allCookiesList).toHaveLength(0)
+  expect(allCookies.size).toBe(0)
 
   // Assert the cookie can't be retrieved given a matching request.
   const reqCookies = store.get(req)
@@ -54,8 +52,7 @@ test('does not return expired cookies', async () => {
 
   // Assert cookie entry has been deleted.
   const allCookies = store.getAll()
-  const allCookiesList = Array.from(allCookies.entries())
-  expect(allCookiesList).toHaveLength(0)
+  expect(allCookies.size).toBe(0)
 
   // Assert the cookie can't be retrieved given a matching request.
   const reqCookies = store.get(req)
@@ -74,8 +71,7 @@ test('does not return cookies after the max age', async () => {
 
   // Assert cookie entry has been deleted.
   const allCookies = store.getAll()
-  const allCookiesList = Array.from(allCookies.entries())
-  expect(allCookiesList).toHaveLength(0)
+  expect(allCookies.size).toBe(0)
 
   // Assert the cookie can't be retrieved given a matching request.
   const reqCookies = store.get(req)
@@ -155,8 +151,7 @@ test('deletes an existing cookie when setting a cookie with the same name and ex
 
   // Assert cookie entry has been deleted.
   const allCookies = store.getAll()
-  const allCookiesList = Array.from(allCookies.entries())
-  expect(allCookiesList).toHaveLength(0)
+  expect(allCookies.size).toBe(0)
 
   // Assert the cookie can't be retrieved given a matching request.
   const reqCookies = store.get(req)
@@ -178,8 +173,7 @@ test('deletes an existing cookie when setting a cookie with the same name and a 
 
   // Assert cookie entry has been deleted.
   const allCookies = store.getAll()
-  const allCookiesList = Array.from(allCookies.entries())
-  expect(allCookiesList).toHaveLength(0)
+  expect(allCookies.size).toBe(0)
 
   // Assert the cookie can't be retrieved given a matching request.
   const reqCookies = store.get(req)


### PR DESCRIPTION
This PR is meant to fix mswjs/msw#708. Apparently the current implementation is filtering expired cookies before adding them to the internal store. This seems to be clever but prevents overwriting existing cookies.