### PR TITLE
Make localStorage support test more transparent

### DIFF
--- a/src/CookieStore.ts
+++ b/src/CookieStore.ts
@@ -24,9 +24,13 @@ function supportsLocalStorage() {
     if (localStorage == null) {
       return false
     }
+    
+    const testKey = PERSISTENCY_KEY + '_test'
 
-    localStorage.setItem('test', 'test')
-    localStorage.getItem('test')
+    localStorage.setItem(testKey, 'test')
+    localStorage.getItem(testKey)
+    localStorage.removeItem(testKey)
+
     return true
   } catch (error) {
     return false


### PR DESCRIPTION
The test that is run for Local Storage support was previously setting the key
`test` as the value `"test"`, and it wasn't cleaning up after itself. This could
be confusing for developers (it was for me!). To alleviate confusion and prevent
potential namespace collision, the test now calls out MSW by name in the key
itself. It also cleans up after itself.