### PR TITLE
chore(release): use "NPM_AUTH_TOKEN" secret for yarn

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,4 @@ jobs:
         run: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
`NODE_AUTH_TOKEN` works for NPM but Yarn seems to require `NPM_AUTH_TOKEN`

- [See explanation](https://github.com/actions/setup-node/issues/81#issuecomment-798905805)