### PR TITLE
ci(ci.yml): use node-version 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 16
           cache: yarn
 
       - name: Install dependencies


### PR DESCRIPTION
instead of 16.14. For consistency with other workflows using node.

Relates to https://github.com/mswjs/msw/issues/1304