### PR TITLE
ci(release): use node-version 16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 16
           cache: yarn
 
       # Configure the Git user that'd author release commits.


### PR DESCRIPTION
instead of 16.14. For consistency with other workflows using node.

Relates to https://github.com/mswjs/msw/issues/1304