### PR TITLE
ci(ci.yml): run CI with multiple versions of Node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16]
+        node_version: [14, 16]
     steps:
       - uses: actions/checkout@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: ${{ matrix.node_version }}
           cache: yarn
 
       - name: Install dependencies


### PR DESCRIPTION
# Description
Run CI with multiple versions of Node.

# Context
A matrix with a list of Node versions was already there but it is not used.

More details here: https://github.com/mswjs/cookies/pull/22